### PR TITLE
cycle infra definitions

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -86,5 +86,49 @@ preset_queries = list(
  (cycleway_right in ('lane', 'shared_busway')) or
  (cycleway_both='lane') or
  (cycleway='lane')
- "
+ ",
+  # traffic-free cycle routes
+  cycle_traffic_free = "select * from 'lines' where
+ (highway='cycleway')
+ ",
+  # cycle lanes (on-road)
+  cycle_lane = "select * from 'lines' where
+ (cycleway='opposite' and oneway_bicycle='no') or
+ (cycleway_left='track') or
+ (cycleway_right='track') or
+ (cycleway_both='track') or
+ (cycleway in ('lane', 'opposite_lane', 'track', 'opposite_track')) or
+ (cycleway_left='lane') or
+ (cycleway_right='lane') or
+ (cycleway_both='lane')
+ ",
+  # pedestrian paths with cycling (excluding some unpaved paths)
+  cycle_path = "select * from 'lines' where
+ (sidewalk_left_bicycle='yes') or
+ (sidewalk_right_bicycle='yes') or
+ (highway='path' and (bicycle in ('yes', 'official', 'designated')) and surface<>'unpaved') or
+ (highway='pedestrian' and (bicycle in ('yes', 'official', 'designated'))) or
+ (highway='footway' and (bicycle in ('yes', 'official', 'designated'))) or
+ (bicycle='use_sidepath')
+",
+  # cycle routes (can follow roads)
+  cycle_route = "select * from 'lines' where
+(route='bicycle') or
+(lcn='yes') or
+(rcn='yes') or
+(ncn='yes') or
+(network='lcn') or
+(network='rcn') or
+(network='ncn')
+",
+  # other cycle infrastructure
+  cycle_other = "select * from 'lines' where
+ (cycleway_left='shared_lane') or
+ (cycleway_right='shared_lane') or
+ (cycleway_left='shared_busway') or
+ (cycleway_right='shared_busway') or
+ (cycleway='shared_busway') or
+ (cycleway='shared_lane') or
+ (bicycle='designated')
+"
   )


### PR DESCRIPTION
I've added to the query the sets of OSM tags that I used in the atumEdinburgh work. 

To get these, I made sure to go through every possible combination of tags in a logical manner, including several that are excluded in the Heidelberg example (perhaps because those specific tags weren't found in Heidelberg). I also removed some tags that clearly don't refer to cycle infrastructure, e.g. `(highway='footway')` and `(highway='bridleway' and bicycle='no')`. I didn't add in  `(highway='bridleway' and bicycle='yes)` because my aim was to get paved routes for all types of bicycle, not off-road mountain bike routes.

I divided the tags into five groups, as you can see. These relate to different types of infrastructure - traffic free cycle paths, on-road cycle lanes, cycling on pedestrian paths, signed cycle routes, and other. There is some overlap between these categories.